### PR TITLE
Add cookiebanners auto-reject when possible

### DIFF
--- a/preferences/userjs-brace.js
+++ b/preferences/userjs-brace.js
@@ -32,6 +32,10 @@ pref("browser.urlbar.suggest.quicksuggest.sponsored", false);
 pref("browser.urlbar.quicksuggest.dataCollection.enabled", false);
 pref("mailnews.headers.sendUserAgent", false);
 pref("mail.sanitize_date_header", true);
+pref("cookiebanners.bannerClicking.enabled", true);
+pref("cookiebanners.cookieInjector.enabled", true);
+pref("cookiebanners.service.mode", 1);
+pref("cookiebanners.service.mode.privatebrowsing", 1);
 
 //Security
 pref("browser.gnome-search-provider.enabled", false);


### PR DESCRIPTION
This add a few settings to enable cookie banners auto reject when it's possible.

Inspired from https://community.mozilla.org/en/campaigns/firefox-cookie-banner-handling/ and https://github.com/mozilla/cookie-banner-rules-list